### PR TITLE
feat: improve JSON error handling

### DIFF
--- a/internal/helpers/helpers.go
+++ b/internal/helpers/helpers.go
@@ -2,14 +2,10 @@ package helpers
 
 import "fmt"
 
-func JsonUnmarshalCheckError(err error) {
-	if err != nil {
-		panic(fmt.Errorf("could not unmarshall json due to the following error: %v", err))
-	}
+func FormatJsonUnmarshalError(err error) error {
+	return fmt.Errorf("could not unmarshall json due to the following error: %v", err)
 }
 
-func JsonMarshalCheckError(err error) {
-	if err != nil {
-		panic(fmt.Errorf("could not marshall json due to the following error: %v", err))
-	}
+func FormatJsonMarshalError(err error) error {
+	return fmt.Errorf("could not marshall json due to the following error: %v", err)
 }

--- a/qarnot/client.go
+++ b/qarnot/client.go
@@ -73,7 +73,9 @@ func (c *Client) sendRequest(method string, payload []byte, headers map[string]s
 	if resp.StatusCode >= 400 {
 		var reqError errorResponse
 		err := json.Unmarshal(body, &reqError)
-		helpers.JsonUnmarshalCheckError(err)
+		if err != nil {
+			return []byte{}, 0, helpers.FormatJsonUnmarshalError(err)
+		}
 
 		var message string
 		if reqError.Message != "" {

--- a/qarnot/hardware_constraints.go
+++ b/qarnot/hardware_constraints.go
@@ -50,7 +50,9 @@ func (c *Client) ListHardwareConstraints() (HardwareConstraintsResponse, error) 
 
 	var response HardwareConstraintsResponse
 	err = json.Unmarshal(data, &response)
-	helpers.JsonUnmarshalCheckError(err)
+	if err != nil {
+		return HardwareConstraintsResponse{}, helpers.FormatJsonUnmarshalError(err)
+	}
 
 	return response, nil
 }

--- a/qarnot/jobs.go
+++ b/qarnot/jobs.go
@@ -48,23 +48,30 @@ func (c *Client) ListJobs() ([]Job, error) {
 
 	var jobs []Job
 	err = json.Unmarshal(resp, &jobs)
-	helpers.JsonUnmarshalCheckError(err)
+	if err != nil {
+		return nil, helpers.FormatJsonUnmarshalError(err)
+	}
 
 	return jobs, nil
 }
 
 func (c *Client) CreateJob(payload CreateJobPayload) (CreateJobResponse, error) {
+	var response CreateJobResponse
+
 	payloadJson, err := json.Marshal(payload)
-	helpers.JsonMarshalCheckError(err)
+	if err != nil {
+		return response, helpers.FormatJsonMarshalError(err)
+	}
 
 	data, _, err := c.sendRequest("POST", payloadJson, nil, "jobs")
 	if err != nil {
-		return CreateJobResponse{}, err
+		return response, err
 	}
 
-	var response CreateJobResponse
 	err = json.Unmarshal(data, &response)
-	helpers.JsonUnmarshalCheckError(err)
+	if err != nil {
+		return response, helpers.FormatJsonUnmarshalError(err)
+	}
 
 	return response, nil
 }
@@ -100,7 +107,9 @@ func (c *Client) GetJobInfo(uuid string) (Job, error) {
 
 	var job Job
 	err = json.Unmarshal(data, &job)
-	helpers.JsonUnmarshalCheckError(err)
+	if err != nil {
+		return Job{}, helpers.FormatJsonUnmarshalError(err)
+	}
 
 	return job, nil
 }
@@ -113,7 +122,9 @@ func (c *Client) ListJobTasks(uuid string) ([]Task, error) {
 
 	var tasks []Task
 	err = json.Unmarshal(data, &tasks)
-	helpers.JsonUnmarshalCheckError(err)
+	if err != nil {
+		return nil, helpers.FormatJsonUnmarshalError(err)
+	}
 
 	return tasks, nil
 }

--- a/qarnot/profiles.go
+++ b/qarnot/profiles.go
@@ -33,7 +33,9 @@ func (c *Client) ListProfiles() ([]string, error) {
 
 	var profiles []string
 	err = json.Unmarshal(data, &profiles)
-	helpers.JsonUnmarshalCheckError(err)
+	if err != nil {
+		return nil, helpers.FormatJsonUnmarshalError(err)
+	}
 
 	return profiles, nil
 }
@@ -46,7 +48,9 @@ func (c *Client) GetProfileDetails(name string) (ProfileDetails, error) {
 
 	var profileDetails ProfileDetails
 	err = json.Unmarshal(data, &profileDetails)
-	helpers.JsonUnmarshalCheckError(err)
+	if err != nil {
+		return ProfileDetails{}, helpers.FormatJsonUnmarshalError(err)
+	}
 
 	return profileDetails, nil
 }

--- a/qarnot/settings.go
+++ b/qarnot/settings.go
@@ -19,7 +19,9 @@ func (c *Client) GetSettings() (Settings, error) {
 
 	var settings Settings
 	err = json.Unmarshal(data, &settings)
-	helpers.JsonUnmarshalCheckError(err)
+	if err != nil {
+		return Settings{}, helpers.FormatJsonUnmarshalError(err)
+	}
 
 	return settings, nil
 }

--- a/qarnot/tasks.go
+++ b/qarnot/tasks.go
@@ -331,7 +331,9 @@ func (c *Client) ListTasks() ([]Task, error) {
 
 	var tasks []Task
 	err = json.Unmarshal(data, &tasks)
-	helpers.JsonUnmarshalCheckError(err)
+	if err != nil {
+		return tasks, helpers.FormatJsonUnmarshalError(err)
+	}
 
 	return tasks, nil
 }
@@ -345,7 +347,9 @@ func (c *Client) GetTaskInfo(uuid string) (Task, error) {
 
 	var taskInfo Task
 	err = json.Unmarshal(data, &taskInfo)
-	helpers.JsonUnmarshalCheckError(err)
+	if err != nil {
+		return Task{}, helpers.FormatJsonUnmarshalError(err)
+	}
 
 	return taskInfo, nil
 }
@@ -353,17 +357,22 @@ func (c *Client) GetTaskInfo(uuid string) (Task, error) {
 // Will create a task, based on a `CreateTaskPayload`
 // Returns a `UUIDResponse` struct, containing a UUID for the newly created task
 func (c *Client) CreateTask(payload CreateTaskPayload) (UUIDResponse, error) {
+	var response UUIDResponse
+
 	payloadJson, err := json.Marshal(payload)
-	helpers.JsonMarshalCheckError(err)
+	if err != nil {
+		return UUIDResponse{}, helpers.FormatJsonMarshalError(err)
+	}
 
 	data, _, err := c.sendRequest("POST", payloadJson, nil, "tasks")
 	if err != nil {
 		return UUIDResponse{}, fmt.Errorf("could not create task due to the following error : %v", err)
 	}
 
-	var response UUIDResponse
 	err = json.Unmarshal(data, &response)
-	helpers.JsonUnmarshalCheckError(err)
+	if err != nil {
+		return response, helpers.FormatJsonUnmarshalError(err)
+	}
 
 	return response, nil
 }
@@ -377,7 +386,9 @@ func (c *Client) ListTaskSummaries() ([]TaskSummary, error) {
 
 	var summaries []TaskSummary
 	err = json.Unmarshal(data, &summaries)
-	helpers.JsonUnmarshalCheckError(err)
+	if err != nil {
+		return summaries, helpers.FormatJsonUnmarshalError(err)
+	}
 
 	return summaries, nil
 }
@@ -409,7 +420,9 @@ func (c *Client) GetTaskStdout(uuid string) (string, error) {
 
 	var stdout string
 	err = json.Unmarshal(data, &stdout)
-	helpers.JsonUnmarshalCheckError(err)
+	if err != nil {
+		return stdout, helpers.FormatJsonUnmarshalError(err)
+	}
 
 	return stdout, nil
 }
@@ -423,7 +436,9 @@ func (c *Client) GetLastTaskStdout(uuid string) (string, error) {
 
 	var stdout string
 	err = json.Unmarshal(data, &stdout)
-	helpers.JsonUnmarshalCheckError(err)
+	if err != nil {
+		return stdout, helpers.FormatJsonUnmarshalError(err)
+	}
 
 	return stdout, nil
 }
@@ -437,7 +452,9 @@ func (c *Client) GetTaskInstanceStdout(uuid string, instanceId int) (string, err
 
 	var stdout string
 	err = json.Unmarshal(data, &stdout)
-	helpers.JsonUnmarshalCheckError(err)
+	if err != nil {
+		return stdout, helpers.FormatJsonUnmarshalError(err)
+	}
 
 	return stdout, nil
 }
@@ -451,7 +468,9 @@ func (c *Client) GetLastTaskInstanceStdout(uuid string, instanceId int) (string,
 
 	var stdout string
 	err = json.Unmarshal(data, &stdout)
-	helpers.JsonUnmarshalCheckError(err)
+	if err != nil {
+		return stdout, helpers.FormatJsonUnmarshalError(err)
+	}
 
 	return stdout, nil
 }
@@ -465,7 +484,9 @@ func (c *Client) GetTaskStderr(uuid string) (string, error) {
 
 	var stderr string
 	err = json.Unmarshal(data, &stderr)
-	helpers.JsonUnmarshalCheckError(err)
+	if err != nil {
+		return stderr, helpers.FormatJsonUnmarshalError(err)
+	}
 
 	return stderr, nil
 }
@@ -479,7 +500,9 @@ func (c *Client) GetLastTaskStderr(uuid string) (string, error) {
 
 	var stderr string
 	err = json.Unmarshal(data, &stderr)
-	helpers.JsonUnmarshalCheckError(err)
+	if err != nil {
+		return stderr, helpers.FormatJsonUnmarshalError(err)
+	}
 
 	return stderr, nil
 }
@@ -493,7 +516,9 @@ func (c *Client) GetInstanceTaskStderr(uuid string, instanceId int) (string, err
 
 	var stderr string
 	err = json.Unmarshal(data, &stderr)
-	helpers.JsonUnmarshalCheckError(err)
+	if err != nil {
+		return stderr, helpers.FormatJsonUnmarshalError(err)
+	}
 
 	return stderr, nil
 }
@@ -507,7 +532,9 @@ func (c *Client) GetInstanceLastTaskStderr(uuid string, instanceId int) (string,
 
 	var stderr string
 	err = json.Unmarshal(data, &stderr)
-	helpers.JsonUnmarshalCheckError(err)
+	if err != nil {
+		return stderr, helpers.FormatJsonUnmarshalError(err)
+	}
 
 	return stderr, nil
 }
@@ -515,8 +542,9 @@ func (c *Client) GetInstanceLastTaskStderr(uuid string, instanceId int) (string,
 // Will create a periodic snapshot for a task using the UUID as string and a `CreateTaskSnapshotPayload` struct as arguments
 func (c *Client) CreateTaskPeriodicSnapshot(uuid string, payload CreateTaskSnapshotPayload) error {
 	payloadJson, err := json.Marshal(payload)
-	helpers.JsonMarshalCheckError(err)
-
+	if err != nil {
+		return helpers.FormatJsonMarshalError(err)
+	}
 	_, _, err = c.sendRequest("POST", payloadJson, nil, fmt.Sprintf("tasks/%v/snapshot/periodic", uuid))
 	if err != nil {
 		return fmt.Errorf("could not create a task periodic snapshot due to the following error : %v", err)
@@ -528,7 +556,9 @@ func (c *Client) CreateTaskPeriodicSnapshot(uuid string, payload CreateTaskSnaps
 // Will create a unique snapshot for a task using the UUID as string and a `CreateTaskSnapshotPayload` struct as arguments
 func (c *Client) CreateTaskUniqueSnapshot(uuid string, payload CreateTaskSnapshotPayload) error {
 	payloadJson, err := json.Marshal(payload)
-	helpers.JsonMarshalCheckError(err)
+	if err != nil {
+		return helpers.FormatJsonMarshalError(err)
+	}
 
 	_, _, err = c.sendRequest("POST", payloadJson, nil, fmt.Sprintf("tasks/%v/snapshot", uuid))
 	if err != nil {
@@ -541,17 +571,22 @@ func (c *Client) CreateTaskUniqueSnapshot(uuid string, payload CreateTaskSnapsho
 // Will retry a task using the UUID as string, and a `CreateTaskPayload` struct as arguments
 // Return a `UUIDResponse` containing the UUID of the newly retried task
 func (c *Client) RetryTask(uuid string, payload CreateTaskPayload) (UUIDResponse, error) {
+	var response UUIDResponse
+
 	payloadJson, err := json.Marshal(payload)
-	helpers.JsonMarshalCheckError(err)
+	if err != nil {
+		return response, helpers.FormatJsonMarshalError(err)
+	}
 
 	data, _, err := c.sendRequest("POST", payloadJson, nil, fmt.Sprintf("tasks/%v/retry", uuid))
 	if err != nil {
 		return UUIDResponse{}, fmt.Errorf("could not retry task due to the following error : %v", err)
 	}
 
-	var response UUIDResponse
 	err = json.Unmarshal(data, &response)
-	helpers.JsonUnmarshalCheckError(err)
+	if err != nil {
+		return response, helpers.FormatJsonUnmarshalError(err)
+	}
 
 	return response, nil
 }
@@ -559,34 +594,44 @@ func (c *Client) RetryTask(uuid string, payload CreateTaskPayload) (UUIDResponse
 // Will recover a task using the UUID as string, and a `CreateTaskPayload` struct as arguments
 // Return a `UUIDResponse` containing the UUID of the newly recovered task
 func (c *Client) RecoverTask(uuid string, payload CreateTaskPayload) (UUIDResponse, error) {
+	var response UUIDResponse
+
 	payloadJson, err := json.Marshal(payload)
-	helpers.JsonMarshalCheckError(err)
+	if err != nil {
+		return response, helpers.FormatJsonMarshalError(err)
+	}
 
 	data, _, err := c.sendRequest("POST", payloadJson, nil, fmt.Sprintf("tasks/%v/recover", uuid))
 	if err != nil {
 		return UUIDResponse{}, fmt.Errorf("could not recover task due to the following error : %v", err)
 	}
 
-	var response UUIDResponse
 	err = json.Unmarshal(data, &response)
-	helpers.JsonUnmarshalCheckError(err)
+	if err != nil {
+		return response, helpers.FormatJsonUnmarshalError(err)
+	}
 	return response, nil
 }
 
 // Will resume a task using the UUID as string, and a `CreateTaskPayload` struct as arguments
 // Return a `UUIDResponse` containing the UUID of the newly resumed task
 func (c *Client) ResumeTask(uuid string, payload CreateTaskPayload) (UUIDResponse, error) {
+	var response UUIDResponse
+
 	payloadJson, err := json.Marshal(payload)
-	helpers.JsonMarshalCheckError(err)
+	if err != nil {
+		return response, helpers.FormatJsonMarshalError(err)
+	}
 
 	data, _, err := c.sendRequest("POST", payloadJson, nil, fmt.Sprintf("tasks/%v/resume", uuid))
 	if err != nil {
 		return UUIDResponse{}, fmt.Errorf("could not resume task due to the following error : %v", err)
 	}
 
-	var response UUIDResponse
 	err = json.Unmarshal(data, &response)
-	helpers.JsonUnmarshalCheckError(err)
+	if err != nil {
+		return response, helpers.FormatJsonUnmarshalError(err)
+	}
 
 	return response, nil
 }
@@ -594,24 +639,31 @@ func (c *Client) ResumeTask(uuid string, payload CreateTaskPayload) (UUIDRespons
 // Will clone a task using the UUID as string, and a `CreateTaskPayload` struct as arguments
 // Return a `UUIDResponse` containing the UUID of the newly cloned task
 func (c *Client) CloneTask(uuid string, payload CreateTaskPayload) (UUIDResponse, error) {
+	var response UUIDResponse
+
 	payloadJson, err := json.Marshal(payload)
-	helpers.JsonMarshalCheckError(err)
+	if err != nil {
+		return response, helpers.FormatJsonMarshalError(err)
+	}
 
 	data, _, err := c.sendRequest("POST", payloadJson, nil, fmt.Sprintf("tasks/%v/clone", uuid))
 	if err != nil {
 		return UUIDResponse{}, fmt.Errorf("could not clone task due to the following error : %v", err)
 	}
 
-	var response UUIDResponse
 	err = json.Unmarshal(data, &response)
-	helpers.JsonUnmarshalCheckError(err)
+	if err != nil {
+		return response, helpers.FormatJsonUnmarshalError(err)
+	}
 	return response, nil
 }
 
 // Will update the fields of a task using the UUID as an argument, as well as a `UpdateTaskPayload` struct
 func (c *Client) UpdateTask(uuid string, payload UpdateTaskPayload) error {
 	payloadJson, err := json.Marshal(payload)
-	helpers.JsonMarshalCheckError(err)
+	if err != nil {
+		return helpers.FormatJsonMarshalError(err)
+	}
 
 	_, _, err = c.sendRequest("PUT", payloadJson, nil, fmt.Sprintf("tasks/%v", uuid))
 	if err != nil {

--- a/qarnot/users.go
+++ b/qarnot/users.go
@@ -53,7 +53,9 @@ func (c *Client) GetUserInfo() (UserInfo, error) {
 	// Convert data to UserInfo struct
 	var userInfo UserInfo
 	err = json.Unmarshal(data, &userInfo)
-	helpers.JsonUnmarshalCheckError(err)
+	if err != nil {
+		return userInfo, helpers.FormatJsonUnmarshalError(err)
+	}
 
 	// Return UserInfo
 	return userInfo, nil

--- a/qarnot/versions.go
+++ b/qarnot/versions.go
@@ -15,7 +15,9 @@ func (c *Client) GetVersions() ([]Version, error) {
 
 	var versions []Version
 	err = json.Unmarshal(data, &versions)
-	helpers.JsonUnmarshalCheckError(err)
+	if err != nil {
+		return versions, helpers.FormatJsonUnmarshalError(err)
+	}
 
 	return versions, nil
 }


### PR DESCRIPTION
This PR aims at refactoring the old previous code that was present in the library, where an error when using `json.Marshal` and `json.Unmarshal` would cause a panic, instead of returning an err